### PR TITLE
Add minimal coding agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# agent_coder_codex
+# Agent Coder Codex
+
+This project contains a minimal framework for building coding agents.
+
+## Components
+
+- **Planner**: Stateless component that produces the next `PlannerStep` given
+  the current `PlanningContext`. A planner can instruct the agent to display
+  messages, trigger tool use, or finish the task. The repository ships with a
+  trivial `EchoPlanner` and a `ToolPlanner` example.
+- **Agent**: Executes a loop using a planner. It keeps chat history in a
+  `Session` and processes actions like `FinishAction`. Agents hold the set of
+  available `Tool` instances.
+- **Scheduler**: Manages multiple sessions and dispatches tasks to agents.
+- **Tools**: Simple asynchronous helpers for running commands such as Git,
+  running tests or echoing text. Tools operate within the session's sandbox
+  directory.
+- **Sandbox**: Each session owns a sandbox directory that tools operate in.
+- **UserInput**: Represents user queries and uploaded files for multi-modal interaction.
+
+## Example
+
+A basic echo agent is located in `examples/simple_agent.py`:
+
+```bash
+python examples/simple_agent.py
+```
+
+This will run the agent once and print the result using the new `UserInput`
+abstraction.
+
+The `ToolPlanner` demonstrates calling a tool before finishing. Running
+
+```bash
+python examples/simple_agent.py use-tool
+```
+
+will execute the `echo` tool and return its output.

--- a/agent_system/__init__.py
+++ b/agent_system/__init__.py
@@ -1,0 +1,12 @@
+from .agent import Agent, Session
+from .planner import (
+    Planner,
+    EchoPlanner,
+    ToolPlanner,
+    PlanningContext,
+    PlannerStep,
+)
+from .tools import Tool, GitTool, TestTool, EchoTool
+from .sandbox import Sandbox
+from .input import UserInput
+from .events import Message, ToolUse, FinishAction, TaskBegin, TaskEnd

--- a/agent_system/agent.py
+++ b/agent_system/agent.py
@@ -1,0 +1,57 @@
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+from .events import Message, ToolUse, FinishAction
+from .planner import Planner, PlanningContext, PlannerStep
+from .sandbox import Sandbox
+from .tools import Tool
+from .input import UserInput
+
+@dataclass
+class Session:
+    session_id: str
+    chat_history: List[Message] = field(default_factory=list)
+    sandbox: Sandbox = field(default_factory=lambda: Sandbox(Path("./sandbox")))
+
+class Agent:
+    def __init__(self, planner: Planner, tools: Optional[List[Tool]] = None):
+        self.planner = planner
+        self.tools = tools or []
+
+    def _find_tool(self, name: str) -> Optional[Tool]:
+        for tool in self.tools:
+            if tool.name == name:
+                return tool
+        return None
+
+    async def handle(self, session: Session, user_input: UserInput, instruction: str = "") -> str:
+        ctx = PlanningContext(
+            session_id=session.session_id,
+            user_input=user_input,
+            chat_history=session.chat_history,
+            tools=self.tools,
+            sandbox=session.sandbox,
+            instruction=instruction,
+        )
+        while True:
+            step = await self.planner.plan(ctx)
+            session.chat_history.extend(step.messages)
+            for msg in step.messages:
+                print(f"{msg.role}: {msg.content}")
+
+            for action in step.actions:
+                if isinstance(action, FinishAction):
+                    return action.result
+                if isinstance(action, ToolUse):
+                    tool = self._find_tool(action.tool_name)
+                    if not tool:
+                        result = f"Tool {action.tool_name} not found"
+                    else:
+                        result = await tool.run(action.instruction, session.sandbox.path)
+                    tool_msg = Message(role="tool", content=result)
+                    session.chat_history.append(tool_msg)
+            ctx.chat_history = session.chat_history
+            await asyncio.sleep(0)
+

--- a/agent_system/events.py
+++ b/agent_system/events.py
@@ -1,0 +1,34 @@
+"""Event and action primitives shared between planner and agent."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Message:
+    """Simple chat message."""
+
+    role: str
+    content: str
+
+@dataclass
+class ToolUse:
+    tool_name: str
+    instruction: str
+
+@dataclass
+class FinishAction:
+    result: str
+
+
+@dataclass
+class TaskBegin:
+    """Event signalling start of a task."""
+
+    description: str
+
+
+@dataclass
+class TaskEnd:
+    """Event signalling completion of a task."""
+
+    summary: str

--- a/agent_system/input.py
+++ b/agent_system/input.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+@dataclass
+class UserInput:
+    """Multi-modal user input."""
+
+    text: str
+    files: List[Path] = field(default_factory=list)
+    images: List[Path] = field(default_factory=list)

--- a/agent_system/planner.py
+++ b/agent_system/planner.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .events import Message, ToolUse, FinishAction
+from .input import UserInput
+from .sandbox import Sandbox
+from .tools import Tool
+
+@dataclass
+class PlanningContext:
+    session_id: str
+    user_input: UserInput
+    chat_history: List[Message]
+    tools: List[Tool]
+    sandbox: Sandbox
+    instruction: str
+    searched_chunks: Optional[str] = None
+
+@dataclass
+class PlannerStep:
+    messages: List[Message] = field(default_factory=list)
+    actions: List[object] = field(default_factory=list)
+
+class Planner:
+    async def plan(self, ctx: PlanningContext) -> PlannerStep:
+        raise NotImplementedError
+
+class EchoPlanner(Planner):
+    async def plan(self, ctx: PlanningContext) -> PlannerStep:
+        content = f"Echo: {ctx.user_input.text}"
+        return PlannerStep(messages=[Message(role="assistant", content=content)],
+                           actions=[FinishAction(result=content)])
+
+
+class ToolPlanner(Planner):
+    """Planner that requests a tool run then returns its output."""
+
+    async def plan(self, ctx: PlanningContext) -> PlannerStep:
+        # Check if a tool message exists in chat history; if so finish with it.
+        for msg in reversed(ctx.chat_history):
+            if msg.role == "tool":
+                return PlannerStep(actions=[FinishAction(result=msg.content)])
+
+        # Otherwise ask to run the echo tool.
+        return PlannerStep(actions=[ToolUse(tool_name="echo", instruction=ctx.user_input.text)])

--- a/agent_system/sandbox.py
+++ b/agent_system/sandbox.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+import subprocess
+
+@dataclass
+class Sandbox:
+    """Simple sandbox for running commands and manipulating files."""
+
+    path: Path
+
+    def __post_init__(self) -> None:
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def run(self, command: str) -> str:
+        """Run a shell command inside the sandbox and return combined output."""
+        proc = subprocess.run(
+            command,
+            cwd=self.path,
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        return proc.stdout + proc.stderr
+
+    def write_file(self, relative_path: str, data: bytes) -> None:
+        file_path = self.path / relative_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(file_path, "wb") as f:
+            f.write(data)
+
+    def read_file(self, relative_path: str) -> bytes:
+        with open(self.path / relative_path, "rb") as f:
+            return f.read()
+
+    def list_files(self) -> List[str]:
+        return [str(p.relative_to(self.path)) for p in self.path.rglob("*") if p.is_file()]

--- a/agent_system/scheduler.py
+++ b/agent_system/scheduler.py
@@ -1,0 +1,19 @@
+import asyncio
+from typing import Dict
+
+from .agent import Agent, Session
+from .input import UserInput
+
+class Scheduler:
+    def __init__(self):
+        self.sessions: Dict[str, Session] = {}
+
+    def get_session(self, session_id: str) -> Session:
+        if session_id not in self.sessions:
+            self.sessions[session_id] = Session(session_id=session_id)
+        return self.sessions[session_id]
+
+    async def run_task(self, agent: Agent, session_id: str, user_input: UserInput, instruction: str = "") -> str:
+        session = self.get_session(session_id)
+        result = await agent.handle(session, user_input, instruction)
+        return result

--- a/agent_system/tools.py
+++ b/agent_system/tools.py
@@ -1,0 +1,46 @@
+import asyncio
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+
+    async def run(self, instruction: str, sandbox: Path) -> str:
+        raise NotImplementedError
+
+class GitTool(Tool):
+    def __init__(self):
+        super().__init__(name="git", description="Interact with git repositories")
+
+    async def run(self, instruction: str, sandbox: Path) -> str:
+        proc = await asyncio.create_subprocess_shell(instruction, cwd=sandbox,
+                                                     stdout=subprocess.PIPE,
+                                                     stderr=subprocess.STDOUT)
+        out, _ = await proc.communicate()
+        return out.decode()
+
+class TestTool(Tool):
+    def __init__(self):
+        super().__init__(name="pytest", description="Run pytest in sandbox")
+
+    async def run(self, instruction: str, sandbox: Path) -> str:
+        cmd = f"pytest {instruction}"
+        proc = await asyncio.create_subprocess_shell(cmd, cwd=sandbox,
+                                                     stdout=subprocess.PIPE,
+                                                     stderr=subprocess.STDOUT)
+        out, _ = await proc.communicate()
+        return out.decode()
+
+
+class EchoTool(Tool):
+    """Simple tool that echoes the instruction."""
+
+    def __init__(self):
+        super().__init__(name="echo", description="Echo instruction")
+
+    async def run(self, instruction: str, sandbox: Path) -> str:
+        return instruction

--- a/examples/simple_agent.py
+++ b/examples/simple_agent.py
@@ -1,0 +1,27 @@
+import asyncio
+from agent_system.agent import Agent
+from agent_system.planner import EchoPlanner, ToolPlanner
+from agent_system.scheduler import Scheduler
+from agent_system.input import UserInput
+from agent_system.tools import EchoTool
+
+async def main(mode: str = "echo"):
+    if mode == "use-tool":
+        planner = ToolPlanner()
+        agent = Agent(planner, tools=[EchoTool()])
+    else:
+        planner = EchoPlanner()
+        agent = Agent(planner)
+
+    scheduler = Scheduler()
+    result = await scheduler.run_task(
+        agent,
+        session_id="demo",
+        user_input=UserInput(text="hello world"),
+    )
+    print("Result:", result)
+
+if __name__ == "__main__":
+    import sys
+    mode = sys.argv[1] if len(sys.argv) > 1 else "echo"
+    asyncio.run(main(mode))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/test_echo_agent.py
+++ b/tests/test_echo_agent.py
@@ -1,0 +1,25 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import asyncio
+import pytest
+
+from agent_system.agent import Agent, Session
+from agent_system.planner import EchoPlanner, ToolPlanner
+from agent_system.input import UserInput
+from agent_system.tools import EchoTool
+
+@pytest.mark.asyncio
+async def test_echo_agent():
+    planner = EchoPlanner()
+    agent = Agent(planner)
+    session = Session(session_id="t1")
+    result = await agent.handle(session, UserInput(text="ping"))
+    assert "Echo: ping" in result
+
+
+@pytest.mark.asyncio
+async def test_tool_agent():
+    planner = ToolPlanner()
+    agent = Agent(planner, tools=[EchoTool()])
+    session = Session(session_id="t2")
+    result = await agent.handle(session, UserInput(text="pong"))
+    assert result == "pong"


### PR DESCRIPTION
## Summary
- implement base agent, planner, scheduler, and tool interfaces
- provide an echo planner and simple agent loop
- add example script and unit test
- document components in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684049e791b48320b290677b26a6471a